### PR TITLE
Fix code scanning alert no. 5: Server-side request forgery

### DIFF
--- a/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/service/WebsiteTestService.java
+++ b/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/service/WebsiteTestService.java
@@ -15,6 +15,12 @@ public class WebsiteTestService {
     @Autowired
     private RestTemplate rest;
 
+    private boolean isValidUrl(String url) {
+        // Implement URL validation logic here
+        // For example, check if the URL starts with a specific prefix
+        return url.startsWith("http://allowed-domain.com") || url.startsWith("https://allowed-domain.com");
+    }
+
     public String testWebsite(WebsiteTestRequest request) {
         try {
             HttpHeaders headers = new HttpHeaders();
@@ -24,7 +30,11 @@ public class WebsiteTestService {
 
             HttpEntity<String> entity = new HttpEntity<>("", headers);
 
-            return this.rest.exchange(request.url, HttpMethod.GET, entity, String.class).getBody();
+            if (isValidUrl(request.url)) {
+                return this.rest.exchange(request.url, HttpMethod.GET, entity, String.class).getBody();
+            } else {
+                return "Invalid URL";
+            }
         } catch (HttpClientErrorException | HttpServerErrorException e) {
             return "URL returned status code: " + e.getStatusCode();
         }


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Java_1/security/code-scanning/5](https://github.com/digiALERT1/Java_1/security/code-scanning/5)

To fix the SSRF vulnerability, we need to validate the user-provided URL against a whitelist of allowed URLs or ensure that the URL is restricted to a particular host or URL prefix. This can be achieved by implementing a validation method that checks the URL before making the request.

1. Create a method to validate the URL against a whitelist or a specific host.
2. Use this validation method in the `testWebsite` method before making the HTTP request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
