### PR TITLE
Fix code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/service/FileService.java
+++ b/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/service/FileService.java
@@ -11,21 +11,26 @@ public class FileService {
     final static String ALLOWED_PREFIX = "/tmp/files/";
 
     public String readFile(String path) throws FileForbiddenFileException, FileReadException {
-        if(!path.startsWith(ALLOWED_PREFIX)) {
-            throw new FileForbiddenFileException("You are not allowed to read " + path);
-        }
-        try (BufferedReader br = new BufferedReader(new FileReader(path))) {
-            StringBuilder sb = new StringBuilder();
-            String line = br.readLine();
-
-            while (line != null) {
-                sb.append(line);
-                sb.append(System.lineSeparator());
-                line = br.readLine();
+        try {
+            File file = new File(path).getCanonicalFile();
+            if (!file.getPath().startsWith(ALLOWED_PREFIX)) {
+                throw new FileForbiddenFileException("You are not allowed to read " + path);
             }
-            return sb.toString();
+            try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+                StringBuilder sb = new StringBuilder();
+                String line = br.readLine();
+
+                while (line != null) {
+                    sb.append(line);
+                    sb.append(System.lineSeparator());
+                    line = br.readLine();
+                }
+                return sb.toString();
+            } catch (IOException e) {
+                throw new FileReadException(e.getMessage());
+            }
         } catch (IOException e) {
-            throw new FileReadException(e.getMessage());
+            throw new FileReadException("Invalid file path: " + e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Java_1/security/code-scanning/4](https://github.com/digiALERT1/Java_1/security/code-scanning/4)

To fix the problem, we need to enhance the validation of the `path` parameter to ensure it does not contain any directory traversal sequences and is contained within the allowed directory. This can be achieved by normalizing the path and checking that it remains within the allowed directory.

- Normalize the `path` to resolve any `.` or `..` sequences.
- Ensure that the normalized path starts with the allowed prefix and does not escape the allowed directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
