### PR TITLE
Fix code scanning alert no. 2: Cross-site scripting

### DIFF
--- a/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/controller/MainController.java
+++ b/src/main/java/com/datadoghq/workshops/samplevulnerablejavaapp/controller/MainController.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.HtmlUtils;
 
 @RestController
 public class MainController {
@@ -50,7 +51,8 @@ public class MainController {
   public ResponseEntity<String> testWebsite(@RequestBody WebsiteTestRequest request) {
     log.info("Testing website " + request.url);
     String result = websiteTestService.testWebsite(request);
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    String escapedResult = HtmlUtils.htmlEscape(result);
+    return new ResponseEntity<>(escapedResult, HttpStatus.OK);
   }
 
   @RequestMapping(method=RequestMethod.POST, value="/view-file", consumes="application/json")


### PR DESCRIPTION
Fixes [https://github.com/digiALERT1/Java_1/security/code-scanning/2](https://github.com/digiALERT1/Java_1/security/code-scanning/2)

To fix the cross-site scripting vulnerability, we need to ensure that any user-provided data included in the response is properly sanitized or encoded. In this case, we can use the `HtmlUtils` class from the `org.springframework.web.util` package to escape any HTML content in the `result` before returning it in the `ResponseEntity`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
